### PR TITLE
Removing assignment of contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 ## Governance Rules
  1. Requests for additions or changes to the spec are entered as issues in the repo
  2. Comments on the problem and possible solutions are open and anybody can participate
- 3. Priorities and assignments to work on particular issues are decided during a bi-weekly call.
- 4. Contributors assigned to a particular issue will work on a branch and submit a PR.
- 5. Core-team organizations can each state one position:
+ 3. Contributors working on a particular issue will work on a branch and submit a PR.
+ 4. Core-team organizations can each state one position:
     - Agree: The org thinks the change is possitive and approves it.
     - Abstain: The org doesn't have a position on this change, but approves it.
     - Disagree: The org thinks the change is negative but is willing to approve it.
     - Block: The org thinkgs the change is negative and is not willing to approve it until concerns are addressed.
- 6. Orgs have 1 week to comment on PRs, not necessarily stating a position. Lack of comment after one week defaults to "Abstain" position however.
- 7. Before 1 month, orgs have to state their position, lack of definition defaults to "Abstain".
- 8. To incorporate PRs into the spec, no Org has to be blocking it–i.e. all orgs have to either Agree, Abstain or Disagree.
+ 5. Orgs have 1 week to comment on PRs, not necessarily stating a position. Lack of comment after one week defaults to "Abstain" position however.
+ 6. Before 1 month, orgs have to state their position, lack of definition defaults to "Abstain".
+ 7. To incorporate PRs into the spec, no Org has to be blocking it–i.e. all orgs have to either Agree, Abstain or Disagree.
  


### PR DESCRIPTION
We want people to be able to start working on things without waiting for a call.