### PR TITLE
Drafts/1.0.0-rc4-xtra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ This changelog documents material changes to the Flow Results specification. Ver
 - Allow a list of groups, to add to or remove a Contact from multiple groups at once.
 - Add a new action "clear", which removes a Contact from all existing groups without needing to specify them.
 
+#### `Core.SetContactProperty` and `block.config.set_contact_property`
+- Allow setting an array of multiple contact properties within one block. This simplifies common flows compared to using multiple blocks, and improves interoperability.
 
 ## \[1.0.0-rc3] - 2021-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,37 @@ This changelog documents material changes to the Flow Results specification. Ver
 
 ## \[Unreleased]
 
-### Added
+### Deprecated
 
+- `Console.IO` and `ConsoleUI.Print` had theoretical use-cases that did not materialize. They have been removed.
+- Given that the `Console` namespace no longer has blocks, it has been removed.
+
+### Added
 * Webhook block type within the Core namespace (`Core.Webhook`), for asynchronous or synchronous requests to external endpoints during Flow runs. [(#24)](https://github.com/FLOIP/flow-spec/issues/24)
+
+### Changed
+#### Resources
+- Resources have been re-located from the container to the flow to which they apply. Including resources with the flows they belong to is more straightforward for implementers. If a resource needs to be used in multiple places the same URL can be used, but referenced from multiple resources.
+
+#### `MobilePrimitives.OpenResponse`
+- `TEXT.max_response_characters` removed. Behaviour for this feature is unclear. Would the message from a user be rejected if it was too long? Would it be truncated? Since most channels have character inherent character limits anyways, suggest to remove this from the spec and allow vendors to configure a limit with vendor metadata if needed.
+- `IVR.end_recording_digits` added. These will allow a caller to end a recording, instead of waiting for timeout.
+
+#### `MobilePrimitives.SelectOne`
+- `IVR.randomize_choice_order` added. This field works in conjunction with pre-existing `question_prompt`, `choices.prompt` and `IVR.digit_prompts` to present choices in random order to reduce response bias.
+- Clarification: prompt is optional when question_prompt is provided. On IVR, A prompt doesn’t need to be provided for each choice unless question_prompt is provided.
+- Choice tests refactored. IVR and Text test cases are now separate, with text tests defined per-language. 
+
+#### `MobilePrimitives.Numeric`
+- Clarification on what the block’s behaviour is when an invalid input is given.
+“responses less than this will proceed through the default exit” change to “responses less than this will result in a block value of null.”
+
+#### Set Contact Property component
+- Update set contact property component’s definition to consider "blocks with results" instead of all blocks.
+
+#### `Core.SetGroupMembership`
+- Change is_member to boolean on Set Group Membership.
+
 
 ## \[1.0.0-rc3] - 2021-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,6 @@ This changelog documents material changes to the Flow Results specification. Ver
 - Clarification on what the block’s behaviour is when an invalid input is given.
 “responses less than this will proceed through the default exit” change to “responses less than this will result in a block value of null.”
 
-#### Set Contact Property component
-- Update set contact property component’s definition to consider "blocks with results" instead of all blocks.
-
 #### `Core.SetGroupMembership`
 - Change is_member to boolean on Set Group Membership.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,14 @@ This changelog documents material changes to the Flow Results specification. Ver
 #### Resources
 - Resources have been re-located from the container to the flow to which they apply. Including resources with the flows they belong to is more straightforward for implementers. If a resource needs to be used in multiple places the same URL can be used, but referenced from multiple resources.
 
+#### Response Blocks (`OpenResponse`, `Numeric`, `SelectOne`, `SelectMany`)
+- Clarify that prompts are optional (but recommended). This enables legacy conversions where prompts have been sent to the Contact in a previous Message block, and it's not possible to merge the Message block with the Response block. In the case where no prompt exists, the block will wait silently for a response.
+
 #### `MobilePrimitives.OpenResponse`
 - `TEXT.max_response_characters` removed. Behaviour for this feature is unclear. Would the message from a user be rejected if it was too long? Would it be truncated? Since most channels have character inherent character limits anyways, suggest to remove this from the spec and allow vendors to configure a limit with vendor metadata if needed.
 - `IVR.end_recording_digits` added. These will allow a caller to end a recording, instead of waiting for timeout.
 
-#### `MobilePrimitives.SelectOne`
+#### `MobilePrimitives.SelectOne` and `MobilePrimitives.SelectMany`
 - `IVR.randomize_choice_order` added. This field works in conjunction with pre-existing `question_prompt`, `choices.prompt` and `IVR.digit_prompts` to present choices in random order to reduce response bias.
 - Clarification: prompt is optional when question_prompt is provided. On IVR, A prompt doesn’t need to be provided for each choice unless question_prompt is provided.
 - Choice tests refactored. IVR and Text test cases are now separate, with text tests defined per-language. 
@@ -30,7 +33,8 @@ This changelog documents material changes to the Flow Results specification. Ver
 “responses less than this will proceed through the default exit” change to “responses less than this will result in a block value of null.”
 
 #### `Core.SetGroupMembership`
-- Change is_member to boolean on Set Group Membership.
+- Allow a list of groups, to add to or remove a Contact from multiple groups at once.
+- Add a new action "clear", which removes a Contact from all existing groups without needing to specify them.
 
 
 ## \[1.0.0-rc3] - 2021-07-30

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ This is an initial collaboration between makers of Flow-like platforms and suppo
 4. [Expressions](expressions.md)
 5. [Layers in the Specification](layers/)
    1. [Layer 1: Core](layers/1-core.md)
-   2. [Layer 2: Mobile Primitives](layers/1-mobile-primitives.md)
-   4. [Layer 3: Smart Devices](layers/3-smart-devices.md)
+   2. [Layer 2: Mobile Primitives](layers/2-primitives.md)
+   3. [Layer 3: Smart Devices](layers/3-smart-devices.md)
 
 ## Language
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is an initial collaboration between makers of Flow-like platforms and suppo
 4. [Expressions](expressions.md)
 5. [Layers in the Specification](layers/)
    1. [Layer 1: Core](layers/1-core.md)
-   2. [Layer 2: Mobile Primitives](layers/2-primitives.md)
+   2. [Layer 2: Mobile Primitives](layers/2-mobile-primitives.md)
    3. [Layer 3: Smart Devices](layers/3-smart-devices.md)
 
 ## Language

--- a/flows.md
+++ b/flows.md
@@ -288,15 +288,22 @@ Each exit must specify one of either `test` or `default`. Each block must have e
 
 #### Setting Contact Properties
 
-A common use-case for platforms that run flows on Contacts is to modify the Contact's properties based on the interactions within a flow. To simplify this common use-case, all blocks have a standard capability to specify how a contact property should be updated. This update shall happen immediately prior to following the exit node out of the block. This is specified via the optional `set_contact_property` object within the Block `config`:
+A common use-case for platforms that run flows on Contacts is to modify the Contact's properties based on the interactions within a flow. To simplify this use-case, all blocks have a standard capability to specify how a contact's properties should be updated. This update shall happen immediately prior to following the exit node out of the block. This is specified via the optional `set_contact_property` array within the Block `config`:
 
 ```text
 config {
    ...,
-   set_contact_property: {
-      property_key: <string>
-      property_value: <Expression>
-   }
+   set_contact_property: [
+      {
+         property_key: <string>
+         property_value: <Expression>
+      },
+      {
+         property_key: <string>
+         property_value: <Expression>
+      },
+      ...
+   ]
 }
 ```
 
@@ -323,10 +330,12 @@ The `property_key` is a string attribute within the context of the Contact, and 
    ],
    "config": {
       "prompt": "d99f9833-ace6-4f7f-957e-0a516e3dbb47"
-      "set_contact_property": {
-         "property_key": "gender"
-         "property_value": "block.value"
-      }
+      "set_contact_property": [
+         {
+            "property_key": "gender"
+            "property_value": "block.value"
+         }
+      ]
    }
 }
 ```

--- a/flows.md
+++ b/flows.md
@@ -26,7 +26,7 @@ Throughout the specification, the terms "string", "object", and "array" refer to
 
 A Resource describes a collection of localized strings or media resources, used when content needs to be presented to Contacts in multiple languages. Resources have the following logical structure:
 
-```text
+```json
 Resource {
   uuid: string,
   values: ResourceValue[]
@@ -59,7 +59,7 @@ SupportedMode {
 
 for example,
 
-```text
+```json
 {
    uuid: "c2dbafbd-e9bd-408f-aabc-25cf67040002",
    values: [
@@ -117,7 +117,7 @@ The _recommended_ structure for Language Identifier strings is:
 
 #### Language Example
 
-```text
+```json
 languages: [
    {
       id: "eng-male",
@@ -155,7 +155,7 @@ languages: [
 
 The term "uuid" refers to a universally unique identifier. Implementations may use any UUID version from [RFC4122](https://tools.ietf.org/html/rfc4122) or [Version 6 IDs](https://bradleypeabody.github.io/uuidv6/). Platforms are recommended to use version 6 IDs for performance and compatibility. The hyphenated string representation of the UUID must be used within JSON documents, for instance:
 
-```text
+```json
 "uuid":"2b375764-9fcc-11e7-abc4-cec278b6b50a"
 ```
 
@@ -180,7 +180,7 @@ A Container is a "package" document containing one or more Flow Definitions, use
 
 #### Example
 
-```text
+```json
 {
    "specification_version": "1.0.0-rc1",
    "uuid": "95f29456-8a33-4d26-b22a-00b0b169056c",
@@ -223,7 +223,7 @@ Possible modes for `supported_modes` are:
 
 #### Flow Example
 
-```text
+```json
 {
    "uuid": "06c912aa-0d36-4d9c-b144-0cd3a38e8293",
    "name": "Summary Case Report Test",
@@ -290,7 +290,7 @@ Each exit must specify one of either `test` or `default`. Each block must have e
 
 A common use-case for platforms that run flows on Contacts is to modify the Contact's properties based on the interactions within a flow. To simplify this use-case, all blocks have a standard capability to specify how a contact's properties should be updated. This update shall happen immediately prior to following the exit node out of the block. This is specified via the optional `set_contact_property` array within the Block `config`:
 
-```text
+```json
 config {
    ...,
    set_contact_property: [
@@ -311,7 +311,7 @@ The `property_key` is a string attribute within the context of the Contact, and 
 
 #### Block Example
 
-```text
+```json
 {
    "uuid": "0a0da5ab-66bc-4cd5-94c1-1e97f1875ee0",
    "vendor_metadata": {},

--- a/flows.md
+++ b/flows.md
@@ -288,7 +288,7 @@ Each exit must specify one of either `test` or `default`. Each block must have e
 
 #### Setting Contact Properties
 
-A common use-case for platforms that run flows on Contacts is to modify the Contact's properties based on the interactions within a flow. To simplify this common use-case, all blocks have a standard capability to specify how a contact property should be updated. This update shall happen immediately prior to following the exit node out of the block. This is specified via the optional `set_contact_property` object within the Block `config`:
+A common use-case for platforms that run flows on Contacts is to modify the Contact's properties based on the interactions within a flow. To simplify this common use-case, all blocks that can produce a result have a standard capability to specify how a contact property should be updated. This update shall happen immediately prior to following the exit node out of the block. This is specified via the optional `set_contact_property` object within the Block `config`:
 
 ```text
 config {

--- a/flows.md
+++ b/flows.md
@@ -288,7 +288,7 @@ Each exit must specify one of either `test` or `default`. Each block must have e
 
 #### Setting Contact Properties
 
-A common use-case for platforms that run flows on Contacts is to modify the Contact's properties based on the interactions within a flow. To simplify this common use-case, all blocks that can produce a result have a standard capability to specify how a contact property should be updated. This update shall happen immediately prior to following the exit node out of the block. This is specified via the optional `set_contact_property` object within the Block `config`:
+A common use-case for platforms that run flows on Contacts is to modify the Contact's properties based on the interactions within a flow. To simplify this common use-case, all blocks have a standard capability to specify how a contact property should be updated. This update shall happen immediately prior to following the exit node out of the block. This is specified via the optional `set_contact_property` object within the Block `config`:
 
 ```text
 config {

--- a/layers/1-core.md
+++ b/layers/1-core.md
@@ -190,9 +190,9 @@ A common use-case for platforms that run flows on Contacts is to modify the Cont
 
 | Key | Description |
 | :--- | :--- |
-| `set_contact_property` \(object, required\) | See below |
+| `set_contact_property` \(array, required\) | See below |
 
-#### `set_contact_property` object
+#### `set_contact_property` array items
 
 | Key | Description |
 | :--- | :--- |
@@ -207,16 +207,22 @@ The `property_key` is a string attribute within the context of the Contact, and 
 
 ### Example
 
-```text
+```
 {
     "type": "Core.SetContactProperty",
     "name": "test_contact_property",
     "label": "Test Contact Property",
     "config": {
-      "set_contact_property": {
-        "property_key": "gender",
-        "property_value": "male"
-      }
+      "set_contact_property": [
+        {
+          "property_key": "gender",
+          "property_value": "male"
+        },
+        {
+          "property_key": "age_range",
+          "property_value": "18_to_30"
+        }
+      ]
     },
     "exits": [
       {

--- a/layers/1-core.md
+++ b/layers/1-core.md
@@ -242,11 +242,11 @@ Another common operation for platforms that run flows on Contacts is to organize
 | :--- | :--- |
 | `group_key` \(string\) | An identifier for the group that membership will be set within. |
 | `group_name` \(string, optional\) | A human-readable label in addition to the `group_key`, in cases where the `group_name` needs to be displayed to the Contact. |
-| `is_member` \(expression, boolean\) | Determines the membership state: falsy to remove the contact from the group, truthy to add, and null for no change to the existing membership. |
+| `is_member` \(boolean\) | Determines the membership state: false to remove the contact from the group, true to add. |
 
 ### Detailed Behaviour
 
-The Contact's membership in the group shall be set according to the `is_member` expression, immediately before following the exit node out of the block.
+The Contact's membership in the group shall be set according to the `is_member` boolean, immediately before following the exit node out of the block.
 
 The `group_key` is a string and is not further restricted by the spec. For complete block interoperability across vendors, vendors would need to agree on the format and identity of `group_key`.
 

--- a/layers/1-core.md
+++ b/layers/1-core.md
@@ -234,33 +234,67 @@ The `property_key` is a string attribute within the context of the Contact, and 
 * Suggested number of exits: 1
 * Supported channels: all
 
-Another common operation for platforms that run flows on Contacts is to organize Contacts into groups based on the results of flow interactions. \(Examples include managing sign-ups for opt-in campaigns, organizing Contacts into demographic groups, etc.\)
+Another common operation for platforms that run flows on Contacts is to organize Contacts into groups based on the results of flow interactions. \(Examples include managing sign-ups for opt-in campaigns, organizing Contacts into demographic groups, etc.\) This block adds or removes the Contact from one or more groups. It can also clear all existing group memberships.
 
 ### Block `config`
 
 | Key | Description |
 | :--- | :--- |
+| `groups` \(array, optional\) | A list of groups to add or remove the Contact from. (See below)
+| `is_member` \(boolean, optional\) | Determines the membership state: false to remove the contact from the group, true to add. |
+| `clear` \(boolean, optional\) | Used instead of `groups` and `is_member`, to remove a Contact from all the groups they are in. This is useful to clear group membership without needing to know all of the Contact's existing groups. |
+
+#### `groups` array items
+
+| Key | Description |
+| :--- | :--- |
 | `group_key` \(string\) | An identifier for the group that membership will be set within. |
 | `group_name` \(string, optional\) | A human-readable label in addition to the `group_key`, in cases where the `group_name` needs to be displayed to the Contact. |
-| `is_member` \(boolean\) | Determines the membership state: false to remove the contact from the group, true to add. |
 
 ### Detailed Behaviour
 
-The Contact's membership in the group shall be set according to the `is_member` boolean, immediately before following the exit node out of the block.
+- When `groups` and `is_member` is provided: The Contact will be added to the groups when `is_member` is true, and removed from the groups (if present) when `is_member` is false. This is done immediately before following the exit node out of the block.
+- When `clear` is provided and set to `true`: The Contact is removed from all of their existing groups.
 
 The `group_key` is a string and is not further restricted by the spec. For complete block interoperability across vendors, vendors would need to agree on the format and identity of `group_key`.
 
 ### Example
 
-```text
+#### Adding a Contact to a group:
+
+```
 {
     "type": "Core.SetGroupMembership",
     "name": "ContactGMBlock",
     "label": "Test Group Membership",
     "config": {
-      "group_key": "7294",
-      "group_name": "Healthcare workers",
+      groups: [
+        {
+          "group_key": "7294",
+          "group_name": "Healthcare workers",
+        }
+      ],
       "is_member": true,
+    },
+    "exits": [
+      {
+        "uuid": "c43106ba-be75-4a86-8da4-837de8348a22",
+        "name": "Default",
+        "default": true,
+      }
+    ]
+  }
+```
+
+#### Removing a Contact from all their existing groups:
+
+```
+{
+    "type": "Core.SetGroupMembership",
+    "name": "ContactGMBlock",
+    "label": "Remove all Group Memberships",
+    "config": {
+      "clear": true,
     },
     "exits": [
       {

--- a/layers/1-core.md
+++ b/layers/1-core.md
@@ -34,13 +34,13 @@ The Context for a Flow shall have a `log` key, which preserves a mapping of time
 
 e.g.,
 
-```text
+```json
 "2017-03-05T12:30:42.123+00:00":"This is a sample log message."
 ```
 
 ### Example
 
-```text
+```json
 {
   "type": "Core.Log",
   "name": "test_log_block",
@@ -90,7 +90,7 @@ Truthy values include all values that are not `0`, `false`, `null`, or `undefine
 
 ### Example
 
-```text
+```json
 {
   "type": "Core.Case",
   "name": "patient_age_decision",
@@ -143,7 +143,7 @@ Multiple levels of nested Flows shall be supported. When an inner Flow terminate
 
 ### Example
 
-```text
+```json
     [...]
     "type": "Core.RunFlow",
     "name": "RunAnotherFlow",
@@ -174,7 +174,7 @@ Not all block interactions and low-level logs are important to users; most users
 
 ### Example
 
-```text
+```json
 TODO
 ```
 

--- a/layers/2-mobile-primitives.md
+++ b/layers/2-mobile-primitives.md
@@ -73,8 +73,22 @@ Each choice in `choices` has the following elements:
 | Key | Description |
 | :--- | :--- |
 | `name` \(string\) | Key identifying this choice. This is what will be written into the block output (`block.value`) when a contact selects this choice, e.g. "chocolate" or "Somewhat Agree". |
-| `test` \(expression\) | The first choice with an expression that evaluates to a truthy value is the selected choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1" |
+| `ivr_test` \(object, optional\) | See below.|
+| `text_tests` \(array of objects, optional\) | See below|
 | `prompt` \(resource\) | Resource used to present/display/announce this choice to contacts, appropriate for the language and mode. |
+
+#### `ivr_test` object
+This test applies to IVR flows.
+| Key | Description |
+| :--- | :--- |
+| `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the seelcted choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1". IVR responsed are not expected to vary across languages, so this test applies to all. \). |
+
+#### `text_test` object
+These tests apply to non-IVR flows. There may be multiple tests per choice: any matching test will indicate that the choice has been selected.
+| Key | Description |
+| :--- | :--- |
+| `language` \(string, optional\) |[Language Identifier](flows.md#language-identifiers) for which this test applies. If omitted, the test will apply to all languages. Multiple tests may apply to the same language. |
+| `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the seelcted choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1" \). |
 
 #### Channel-specific `config`:
 
@@ -135,41 +149,62 @@ This block writes the `name` of the selected choice to the output variable corre
       {
         "name": "chocolate",
         "prompt": "b0f6d3ec-b9ec-4761-b280-6777d965deab",
-        "test": "OR(
-            AND(flow.mode = 'IVR', block.response = 7), 
-            AND(flow.mode != 'IVR', 
-              OR(
-                AND(flow.language = 'eng', OR(block.response = 1, block.response = 'chocolate')), 
-                AND(flow.language = 'fre', OR(block.response = 1, block.response = 'chocolat'))
-              )
-            )
-          )"
+        "ivr_test": {
+          "test_expression": "block.response = '7'"
+        }
+        "text_tests": [
+          {
+            "test_expression": "block.response = '1'"
+          },
+          {
+            "language": "eng",
+            "test_expression": "block.response = 'chocolate'"
+          },
+          {
+            "language": "fre",
+            "test_expression": "block.response = 'chocolat'"
+          },
+        ]
       },
       {
         "name": "vanilla",
         "prompt": "b75fa302-8ff7-4f49-bf26-8f915e807222",
-        "test": "OR(
-            AND(flow.mode = 'IVR', block.response = 8), 
-            AND(flow.mode != 'IVR', 
-              OR(
-                AND(flow.language = 'eng', OR(block.response = 2, block.response = 'vanilla')), 
-                AND(flow.language = 'fre', OR(block.response = 2, block.response = 'vanille'))
-              )
-            )
-          )"
+        "ivr_test": {
+          "test_expression": "block.response = '8'"
+        }
+        "text_tests": [
+          {
+            "test_expression": "block.response = '2'"
+          },
+          {
+            "language": "eng",
+            "test_expression": "block.response = 'vanilla'"
+          },
+          {
+            "language": "fre",
+            "test_expression": "block.response = 'vanille'"
+          },
+        ]
       },
       {
         "name": "strawberry",
         "prompt": "22619b04-b06d-483e-af83-ee3ba9c8c867",
-        "test": "OR(
-            AND(flow.mode = 'IVR', block.response = 9), 
-            AND(flow.mode != 'IVR', 
-              OR(
-                AND(flow.language = 'eng', OR(block.response = 3, block.response = 'strawberry')), 
-                AND(flow.language = 'fre', OR(block.response = 3, block.response = 'fraise'))
-              )
-            )
-          )"
+        "ivr_test": {
+          "test_expression": "block.response = '9'"
+        }
+        "text_tests": [
+          {
+            "test_expression": "block.response = '3'"
+          },
+          {
+            "language": "eng",
+            "test_expression": "block.response = 'strawberry'"
+          },
+          {
+            "language": "fre",
+            "test_expression": "block.response = 'fraise'"
+          },
+        ]
       }
     ]
   }

--- a/layers/2-mobile-primitives.md
+++ b/layers/2-mobile-primitives.md
@@ -83,7 +83,7 @@ This test applies to IVR flows.
 | :--- | :--- |
 | `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the selected choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1". IVR responses are not expected to vary across languages, so this test applies to all. \). |
 
-#### `text_test` object
+#### `text_tests` object
 These tests apply to non-IVR flows. There may be multiple tests per choice: any matching test will indicate that the choice has been selected.
 | Key | Description |
 | :--- | :--- |

--- a/layers/2-mobile-primitives.md
+++ b/layers/2-mobile-primitives.md
@@ -40,7 +40,7 @@ None
 
 ### Example
 
-```text
+```json
 {
   "type": "MobilePrimitives.Message",
   "name": "welcome_message",
@@ -116,7 +116,7 @@ This block writes the `name` of the selected choice to the output variable corre
 
 ### Example
 
-```text
+```json
 {
   "type": "MobilePrimitives.SelectOneResponse",
   "name": "favorite_ice_cream",
@@ -394,7 +394,7 @@ This block writes an array of `name`s of the selected choices to the output vari
 
 ### Example
 
-```text
+```json
 [...]
 {
   "type": "MobilePrimitives.SelectManyResponses",
@@ -533,7 +533,7 @@ This block writes the numeric value received to the output variable correspondin
 
 ### Example
 
-```text
+```json
 [...]
 {
   "type": "MobilePrimitives.NumericResponse",
@@ -588,7 +588,7 @@ For `TEXT`, `OFFLINE`, and `RICH_MESSAGING` modes that capture a text response, 
 
 ### Example
 
-```text
+```json
 [...]
 {
   "type": "MobilePrimitives.OpenResponse",

--- a/layers/2-mobile-primitives.md
+++ b/layers/2-mobile-primitives.md
@@ -81,14 +81,14 @@ Each choice in `choices` has the following elements:
 This test applies to IVR flows.
 | Key | Description |
 | :--- | :--- |
-| `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the selected choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1". IVR responsed are not expected to vary across languages, so this test applies to all. \). |
+| `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the selected choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1". IVR responses are not expected to vary across languages, so this test applies to all. \). |
 
 #### `text_test` object
 These tests apply to non-IVR flows. There may be multiple tests per choice: any matching test will indicate that the choice has been selected.
 | Key | Description |
 | :--- | :--- |
 | `language` \(string, optional\) |[Language Identifier](flows.md#language-identifiers) for which this test applies. If omitted, the test will apply to all languages. Multiple tests may apply to the same language. |
-| `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the selected choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1" \). |
+| `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the selected choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1". |
 
 #### Channel-specific `config`:
 
@@ -179,6 +179,10 @@ This block writes the `name` of the selected choice to the output variable corre
           {
             "language": "eng",
             "test_expression": "block.response = 'vanilla'"
+          },
+          {
+            "language": "eng",
+            "test_expression": "block.response = 'plain'"
           },
           {
             "language": "fre",

--- a/layers/2-mobile-primitives.md
+++ b/layers/2-mobile-primitives.md
@@ -75,7 +75,7 @@ Each choice in `choices` has the following elements:
 | `name` \(string\) | Key identifying this choice. This is what will be written into the block output (`block.value`) when a contact selects this choice, e.g. "chocolate" or "Somewhat Agree". |
 | `ivr_test` \(object, optional\) | See below.|
 | `text_tests` \(array of objects, optional\) | See below|
-| `prompt` \(resource\) | Resource used to present/display/announce this choice to contacts, appropriate for the language and mode. |
+| `prompt` \(resource, optional\) | Resource used to present/display/announce this choice to contacts, appropriate for the language and mode. |
 
 #### `ivr_test` object
 This test applies to IVR flows.

--- a/layers/2-mobile-primitives.md
+++ b/layers/2-mobile-primitives.md
@@ -60,11 +60,13 @@ None
 
 This block obtains the answer to a Multiple Choice question from the contact. The contact must choose a single choice from a set of choices.
 
+This block can be configured to have a single exit, or a number of exits with possibilities based on the response given. The exit specification is as described in [Block `exits`](../flows.md#blocks).
+
 ### Block `config`
 
 | Key | Description |
 | :--- | :--- |
-| `prompt` \(resource, optional\) | The question prompt that should be displayed to the contact, e.g. "What is your favorite kind of ice cream? Reply 1 for chocolate, 2 for vanilla, and 3 for strawberry." `prompt` may be optional when `question_prompt` is provided.|
+| `prompt` \(resource, optional\) | The question prompt that should be displayed to the contact, e.g. "What is your favorite kind of ice cream? Reply 1 for chocolate, 2 for vanilla, and 3 for strawberry." Either `prompt` or `question_prompt` should be provided. (For legacy compatibility, implementations may omit prompts completely when guidance has been given to the Contact in a previous block, but this is not recommended. In this case, the block will wait silently for a response.) |
 | `question_prompt` \(resource, optional\) | For instances when the question prompt should be separated from the presentation of choices, e.g. "What is your favorite kind of ice cream?". If included, blocks must provide suitable resources within `choices` to present the choices on each supported mode. For the `IVR` mode, they must also provide `digit_prompts`. |
 | `choices` \(array of choices\) | Set of choices to select from. See choices configuration below. |
 
@@ -77,13 +79,13 @@ Each choice in `choices` has the following elements:
 | `text_tests` \(array of objects, optional\) | See below|
 | `prompt` \(resource, optional\) | Resource used to present/display/announce this choice to contacts, appropriate for the language and mode. |
 
-#### `ivr_test` object
+##### `ivr_test` object
 This test applies to IVR flows.
 | Key | Description |
 | :--- | :--- |
 | `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the selected choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1". IVR responses are not expected to vary across languages, so this test applies to all. \). |
 
-#### `text_tests` object
+##### `text_tests` object
 These tests apply to non-IVR flows. There may be multiple tests per choice: any matching test will indicate that the choice has been selected.
 | Key | Description |
 | :--- | :--- |
@@ -95,9 +97,7 @@ These tests apply to non-IVR flows. There may be multiple tests per choice: any 
 | Key | Description |
 | :--- | :--- |
 | `IVR`: `digit_prompts` \(array of resources\) | An ordered set of audio prompts, with the same length as `choices`, with content such as "Press 1", "Press 2", "Press 3". This is required when using `question_prompt` to present choices individually.  |
-| `IVR`: `randomize_choice_order` \(boolean\) | In conjunction with `question_prompt`, `choices_prompt`, and `IVR.digit_prompts`, this indicates that the presentation of choices should be in random order.|
-
-This block can be configured to have a single exit, or a number of exits with possibilities based on the response given. The exit specification is as described in [Block `exits`](../flows.md#blocks).
+| `IVR`: `randomize_choice_order` \(boolean, optional\) | Indicates that the choices should be presented in a random order to each Contact. (Used to minimize response order bias in surveying). Default false. Requires the use of `question_prompt`, `choices_prompt`, and `IVR.digit_prompts` to present choices individually. |
 
 ### Detailed behaviour by mode
 
@@ -331,7 +331,7 @@ This block writes the `name` of the selected choice to the output variable corre
 ## Select Many Responses \(Multiple Choice Question\) Block
 
 * Type: `MobilePrimitives.SelectManyResponses`
-* Suggested number of exits: 1 + default exit (used in case of error or invalid input), or multiple exits based on choices
+* Suggested number of exits: 1 + default exit (used in case of error or invalid input).
 * Supported modes: `IVR`, `TEXT`, `RICH_MESSAGING`, `OFFLINE`
 
 This block obtains the answer to a Multiple Choice question from the contact. The contact can select from zero to many options from a set of choices.
@@ -340,7 +340,7 @@ This block obtains the answer to a Multiple Choice question from the contact. Th
 
 | Key | Description |
 | :--- | :--- |
-| `prompt` \(resource\) | The question prompt that should be displayed to the contact, e.g. "What kinds of ice cream do you like: chocolate, vanilla, strawberry? Select all that apply." |
+| `prompt` \(resource, optional\) | The question prompt that should be displayed to the contact, e.g. "What kinds of ice cream do you like: chocolate, vanilla, strawberry? Select all that apply." Either `prompt` or `question_prompt` should be provided. (For legacy compatibility, implementations may omit prompts completely when guidance has been given to the Contact in a previous block, but this is not recommended. In this case, the block will wait silently for a response.) |
 | `question_prompt` \(resource, optional\) | For instances when the question prompt should be separated from the presentation of choices, e.g. "What is your favorite kind of ice cream?". If included, blocks must provide suitable resources within `choices` to present the choices on each supported mode. For the `IVR` mode, they must also provide `digit_prompts`. |
 | `choices` \(array of choices\) | Set of choices to select from. See choices configuration below. |
 | `minimum_choices` \(integer, optional\) | The minimum number of choices the Contact must select to proceed. Default if not provided: 0. |
@@ -351,10 +351,31 @@ Each choice in `choices` has the following elements:
 | Key | Description |
 | :--- | :--- |
 | `name` \(string\) | Key identifying this choice. This is what will be written into the block output (`block.value`) when a contact selects this choice, e.g. "chocolate" or "Somewhat Agree". |
-| `test` \(expression\) | Any choice with an expression that evaluates to a truthy value is a selected choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1" |
+| `ivr_test` \(object, optional\) | See below.|
+| `text_tests` \(array of objects, optional\) | See below|
 | `prompt` \(resource\) | Resource used to present/display/announce this choice to contacts, appropriate for the language and mode. |
 
 This block can be configured to have a single exit, or a number of exits with possibilities based on the response given. The exit specification is as described in [Block `exits`](../flows.md#blocks).
+
+##### `ivr_test` object
+This test applies to IVR flows.
+| Key | Description |
+| :--- | :--- |
+| `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the selected choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1". IVR responses are not expected to vary across languages, so this test applies to all. \). |
+
+##### `text_tests` object
+These tests apply to non-IVR flows. There may be multiple tests per choice: any matching test will indicate that the choice has been selected.
+| Key | Description |
+| :--- | :--- |
+| `language` \(string, optional\) |[Language Identifier](flows.md#language-identifiers) for which this test applies. If omitted, the test will apply to all languages. Multiple tests may apply to the same language. |
+| `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the selected choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1". |
+
+#### Channel-specific `config`:
+
+| Key | Description |
+| :--- | :--- |
+| `IVR`: `digit_prompts` \(array of resources\) | An ordered set of audio prompts, with the same length as `choices`, with content such as "Press 1", "Press 2", "Press 3". This is required when using `question_prompt` to present choices individually.  |
+| `IVR`: `randomize_choice_order` \(boolean, optional\) | Indicates that the choices should be presented in a random order to each Contact. (Used to minimize response order bias in surveying). Default false. Requires the use of `question_prompt`, `choices_prompt`, and `IVR.digit_prompts` to present choices individually. |
 
 ### Detailed behaviour by mode
 
@@ -408,41 +429,66 @@ This block writes an array of `name`s of the selected choices to the output vari
       {
         "name": "chocolate",
         "prompt": "b0f6d3ec-b9ec-4761-b280-6777d965deab",
-        "test": "OR(
-            AND(flow.mode = 'IVR', block.response = 7), 
-            AND(flow.mode != 'IVR', 
-              OR(
-                AND(flow.language = 'eng', OR(block.response = 1, block.response = 'chocolate')), 
-                AND(flow.language = 'fre', OR(block.response = 1, block.response = 'chocolat'))
-              )
-            )
-          )"
+        "ivr_test": {
+          "test_expression": "block.response = '7'"
+        }
+        "text_tests": [
+          {
+            "test_expression": "block.response = '1'"
+          },
+          {
+            "language": "eng",
+            "test_expression": "block.response = 'chocolate'"
+          },
+          {
+            "language": "fre",
+            "test_expression": "block.response = 'chocolat'"
+          },
+        ]
       },
       {
         "name": "vanilla",
         "prompt": "b75fa302-8ff7-4f49-bf26-8f915e807222",
-        "test": "OR(
-            AND(flow.mode = 'IVR', block.response = 8), 
-            AND(flow.mode != 'IVR', 
-              OR(
-                AND(flow.language = 'eng', OR(block.response = 2, block.response = 'vanilla')), 
-                AND(flow.language = 'fre', OR(block.response = 2, block.response = 'vanille'))
-              )
-            )
-          )"
+        "ivr_test": {
+          "test_expression": "block.response = '8'"
+        }
+        "text_tests": [
+          {
+            "test_expression": "block.response = '2'"
+          },
+          {
+            "language": "eng",
+            "test_expression": "block.response = 'vanilla'"
+          },
+          {
+            "language": "eng",
+            "test_expression": "block.response = 'plain'"
+          },
+          {
+            "language": "fre",
+            "test_expression": "block.response = 'vanille'"
+          },
+        ]
       },
       {
         "name": "strawberry",
         "prompt": "22619b04-b06d-483e-af83-ee3ba9c8c867",
-        "test": "OR(
-            AND(flow.mode = 'IVR', block.response = 9), 
-            AND(flow.mode != 'IVR', 
-              OR(
-                AND(flow.language = 'eng', OR(block.response = 3, block.response = 'strawberry')), 
-                AND(flow.language = 'fre', OR(block.response = 3, block.response = 'fraise'))
-              )
-            )
-          )"
+        "ivr_test": {
+          "test_expression": "block.response = '9'"
+        }
+        "text_tests": [
+          {
+            "test_expression": "block.response = '3'"
+          },
+          {
+            "language": "eng",
+            "test_expression": "block.response = 'strawberry'"
+          },
+          {
+            "language": "fre",
+            "test_expression": "block.response = 'fraise'"
+          },
+        ]
       }
     ]
   }
@@ -461,7 +507,7 @@ This block obtains a numeric response from the contact.
 
 | Key | Description |
 | :--- | :--- |
-| `prompt` \(resource\) | The question prompt that should be displayed to the contact, e.g. "How old are you? Please reply with your age in years." |
+| `prompt` \(resource, optional\) | The question prompt that should be displayed to the contact, e.g. "How old are you? Please reply with your age in years." (For legacy compatibility, implementations may omit the prompt when guidance has been given to the Contact in a previous block, but this is not recommended. In this case, the block will wait silently for a response.) |
 | `validation_minimum` \(number, optional\) | The minimum value \(inclusive\) that will be accepted as a response to this block; responses less than this will result in a block value of `null`. |
 | `validation_maximum` \(number, optional\) | The maximum value \(inclusive\) that will be accepted as a response to this block; responses greater than this will result in a block value of `null`. |
 
@@ -513,36 +559,20 @@ This block writes the numeric value received to the output variable correspondin
 
 This block obtains an open-ended response from the contact. Dependent on the mode, this is a TEXT response, audio recording, or other type of media recording \(e.g. video\).
 
+This block can be configured to have a single exit, or a number of exits with possibilities based on patterns in the response given. The exit specification is as described in [Block `exits`](../flows.md#blocks).
+
 ### Block `config`
 
-<table>
-  <thead>
-    <tr>
-      <th style="text-align:left">Key</th>
-      <th style="text-align:left">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td style="text-align:left"><code>prompt</code> (resource)</td>
-      <td style="text-align:left">
-        <p>The question prompt that should be displayed to the contact, e.g. &quot;Please
-          leave</p>
-        <p>us feedback on your experience at the Children&apos;s Hospital.&quot;</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+| Key | Description |
+| :--- | :--- |
+| `prompt` \(resource, optional\) | The question prompt that should be displayed to the contact, e.g. "Please leave us feedback on your experience at the Childrens Hospital." (For legacy compatibility, implementations may omit the prompt when guidance has been given to the Contact in a previous block, but this is not recommended. In this case, the block will wait silently for a response.) |
 
 #### Channel-specific `config`:
 
 | Key | Description |
 | :--- | :--- |
 | `IVR`: `max_duration_seconds` \(number\) | The maximum duration to record for, before proceeding to the next block. |
-| `IVR`: `end_recording_digits` \(string, optional\) | A set of key-press buttons that finish an open-ended recording. |
-
-
-This block can be configured to have a single exit, or a number of exits with possibilities based on patterns in the response given. The exit specification is as described in [Block `exits`](../flows.md#blocks).
+| `IVR`: `end_recording_digits` \(string, optional\) | A set of key-press digits that terminate an open-ended recording, e.g.: "1789#" |
 
 ### Detailed behaviour by mode
 

--- a/layers/2-mobile-primitives.md
+++ b/layers/2-mobile-primitives.md
@@ -64,7 +64,7 @@ This block obtains the answer to a Multiple Choice question from the contact. Th
 
 | Key | Description |
 | :--- | :--- |
-| `prompt` \(resource\) | The question prompt that should be displayed to the contact, e.g. "What is your favorite kind of ice cream? Reply 1 for chocolate, 2 for vanilla, and 3 for strawberry." |
+| `prompt` \(resource, optional\) | The question prompt that should be displayed to the contact, e.g. "What is your favorite kind of ice cream? Reply 1 for chocolate, 2 for vanilla, and 3 for strawberry." `prompt` may be optional when `question_prompt` is provided.|
 | `question_prompt` \(resource, optional\) | For instances when the question prompt should be separated from the presentation of choices, e.g. "What is your favorite kind of ice cream?". If included, blocks must provide suitable resources within `choices` to present the choices on each supported mode. For the `IVR` mode, they must also provide `digit_prompts`. |
 | `choices` \(array of choices\) | Set of choices to select from. See choices configuration below. |
 
@@ -81,6 +81,7 @@ Each choice in `choices` has the following elements:
 | Key | Description |
 | :--- | :--- |
 | `IVR`: `digit_prompts` \(array of resources\) | An ordered set of audio prompts, with the same length as `choices`, with content such as "Press 1", "Press 2", "Press 3". This is required when using `question_prompt` to present choices individually.  |
+| `IVR`: `randomize_choice_order` \(boolean\) | In conjunction with `question_prompt`, `choices_prompt`, and `IVR.digit_prompts`, this indicates that the presentation of choices should be in random order.|
 
 This block can be configured to have a single exit, or a number of exits with possibilities based on the response given. The exit specification is as described in [Block `exits`](../flows.md#blocks).
 
@@ -422,8 +423,8 @@ This block obtains a numeric response from the contact.
 | Key | Description |
 | :--- | :--- |
 | `prompt` \(resource\) | The question prompt that should be displayed to the contact, e.g. "How old are you? Please reply with your age in years." |
-| `validation_minimum` \(number, optional\) | The minimum value \(inclusive\) that will be accepted as a response to this block; responses less than this will proceed through the default exit. |
-| `validation_maximum` \(number, optional\) | The maximum value \(inclusive\) that will be accepted as a response to this block; responses greater than this will proceed through the default exit. |
+| `validation_minimum` \(number, optional\) | The minimum value \(inclusive\) that will be accepted as a response to this block; responses less than this will result in a block value of `null`. |
+| `validation_maximum` \(number, optional\) | The maximum value \(inclusive\) that will be accepted as a response to this block; responses greater than this will result in a block value of `null`. |
 
 #### Channel-specific `config`:
 

--- a/layers/2-mobile-primitives.md
+++ b/layers/2-mobile-primitives.md
@@ -81,14 +81,14 @@ Each choice in `choices` has the following elements:
 This test applies to IVR flows.
 | Key | Description |
 | :--- | :--- |
-| `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the seelcted choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1". IVR responsed are not expected to vary across languages, so this test applies to all. \). |
+| `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the selected choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1". IVR responsed are not expected to vary across languages, so this test applies to all. \). |
 
 #### `text_test` object
 These tests apply to non-IVR flows. There may be multiple tests per choice: any matching test will indicate that the choice has been selected.
 | Key | Description |
 | :--- | :--- |
 | `language` \(string, optional\) |[Language Identifier](flows.md#language-identifiers) for which this test applies. If omitted, the test will apply to all languages. Multiple tests may apply to the same language. |
-| `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the seelcted choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1" \). |
+| `test_expression` \(expression\) | The first choice with an expression that evaluates to a truthy value is the selected choice. Often this expression would examine the raw response from the contact, e.g. "block.response = 1" \). |
 
 #### Channel-specific `config`:
 

--- a/layers/3-smart-devices.md
+++ b/layers/3-smart-devices.md
@@ -35,19 +35,19 @@ This block allows a device user to capture a location on a map, e.g. using a GPS
 
 This block writes the location coordinates to the output variable corresponding to the `name` of the block. The format of the coordinates is an array of 4 floating point numbers: latitude, longitude, elevation \(in meters\), and accuracy \(in meters\):
 
-```text
+```json
 [lat, long, elevation, accuracy]
 ```
 
 e.g.
 
-```text
+```json
 [52.0835780,-106.6104880, 501.23, 0.5]
 ```
 
 ### Example
 
-```text
+```json
 TODO
 ```
 


### PR DESCRIPTION
Adding the following changes:

SelectOne
- Add config IVR.randomize_choice_order. Works in conjunction with pre-existing question_prompt, choices.prompt and IVR.digit_prompts to present choices in random order to reduce response bias.  
- Clarification: prompt is optional when question_prompt is provided. On IVR, A prompt doesn’t need to be provided for each choice unless question_prompt is provided.
- Update choice tests -- separate IVR and Text tests; allow text tests to be defined per-language

Numeric Block
- Need clarification on what the block’s behaviour is when an invalid input is given.
“responses less than this will proceed through the default exit” change to “responses less than this will result in a block value of null”

Set Contact Property component
- Update set contact property component’s definition to consider `blocks with results`

Set Group Membership 
- Change is_member to boolean on Set Group Membership